### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/Thirdparty/Line3Dpp/README.md
+++ b/Thirdparty/Line3Dpp/README.md
@@ -32,7 +32,7 @@ If you use our algorithm in any of your publications or projects, please cite ou
     Hofer, M., Maurer, M., and Bischof, H.:
     Efficient 3D Scene Abstraction Using Line Segments,
     In Computer Vision and Image Understanding (CVIU), 2016.
-    http://dx.doi.org/10.1016/j.cviu.2016.03.017
+    https://doi.org/10.1016/j.cviu.2016.03.017
 
 Requirements
 ============

--- a/Thirdparty/Line3Dpp/lsd/lsd.cpp
+++ b/Thirdparty/Line3Dpp/lsd/lsd.cpp
@@ -8,7 +8,7 @@
     "LSD: a Line Segment Detector" by Rafael Grompone von Gioi,
     Jeremie Jakubowicz, Jean-Michel Morel, and Gregory Randall,
     Image Processing On Line, 2012. DOI:10.5201/ipol.2012.gjmr-lsd
-    http://dx.doi.org/10.5201/ipol.2012.gjmr-lsd
+    https://doi.org/10.5201/ipol.2012.gjmr-lsd
 
   Copyright (c) 2007-2011 rafael grompone von gioi <grompone@gmail.com>
 
@@ -57,7 +57,7 @@
       "LSD: a Line Segment Detector" by Rafael Grompone von Gioi,
       Jeremie Jakubowicz, Jean-Michel Morel, and Gregory Randall,
       Image Processing On Line, 2012. DOI:10.5201/ipol.2012.gjmr-lsd
-      http://dx.doi.org/10.5201/ipol.2012.gjmr-lsd
+      https://doi.org/10.5201/ipol.2012.gjmr-lsd
 
     The module's main function is lsd().
 

--- a/Thirdparty/Line3Dpp/lsd/lsd.hpp
+++ b/Thirdparty/Line3Dpp/lsd/lsd.hpp
@@ -8,7 +8,7 @@
     "LSD: a Line Segment Detector" by Rafael Grompone von Gioi,
     Jeremie Jakubowicz, Jean-Michel Morel, and Gregory Randall,
     Image Processing On Line, 2012. DOI:10.5201/ipol.2012.gjmr-lsd
-    http://dx.doi.org/10.5201/ipol.2012.gjmr-lsd
+    https://doi.org/10.5201/ipol.2012.gjmr-lsd
 
   Copyright (c) 2007-2011 rafael grompone von gioi <grompone@gmail.com>
 

--- a/Thirdparty/Line3Dpp/lsd/lsd_wrap.hpp
+++ b/Thirdparty/Line3Dpp/lsd/lsd_wrap.hpp
@@ -9,7 +9,7 @@
  *   2012-03-24
  *   reference
  *     Rafael Grompone von Gioi, Jérémie Jakubowicz, Jean-Michel Morel, and Gregory Randall,
- *     LSD: a Line Segment Detector, Image Processing On Line, 2012. http://dx.doi.org/10.5201/ipol.2012.gjmr-lsd
+ *     LSD: a Line Segment Detector, Image Processing On Line, 2012. https://doi.org/10.5201/ipol.2012.gjmr-lsd
  *
  *  Notes
  *  5/18/2013  Author of LSD, rafael grompone von gioi <grompone@gmail.com>, has allowed the code to be BSD for OpenCV. I will


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but nonetheless, I'd like to suggest to hereby update all static DOI links.

Cheers!